### PR TITLE
Standardize output format #15

### DIFF
--- a/bin/lili
+++ b/bin/lili
@@ -13,7 +13,7 @@ STAT_HEADER = <<-eos
   "statVersion": "0.4.0",
   "process": {
     "name": "Line Ending Linter",
-    "version": "0.3.0",
+    "version": "#{LiLi::VERSION}",
     "description": "lili searches your source code files for strange line endings that may cause issues with software interoperability",
     "maintainer": "Andrew Pennebaker",
     "email": "andrew.pennebaker@gmail.com",

--- a/bin/lili
+++ b/bin/lili
@@ -6,11 +6,35 @@ require 'optparse'
 require 'dotsmack'
 require 'yaml'
 require 'lili'
+require 'json'
+
+STAT_HEADER = <<-eos
+{
+  "statVersion": "0.4.0",
+  "process": {
+    "name": "Line Ending Linter",
+    "version": "0.3.0",
+    "description": "lili searches your source code files for strange line endings that may cause issues with software interoperability",
+    "maintainer": "Andrew Pennebaker",
+    "email": "andrew.pennebaker@gmail.com",
+    "website": "https://github.com/mcandre/lili",
+    "repeatability": "Associative"
+  },
+  "findings": [
+eos
+
+STAT_FOOTER = <<-eos
+
+  ]
+}
+eos
 
 def main
   ignores = DEFAULT_IGNORES
 
   configuration_flags = {}
+
+  is_stat = false
 
   option = OptionParser.new do |option|
     option.banner = 'Usage: lili [options] [<files>]'
@@ -22,6 +46,10 @@ def main
     option.on('-h', '--help', 'Print usage info') do
       puts option
       exit
+    end
+
+    option.on('-s', '--stat', 'Output in STAT') do
+      is_stat = true
     end
 
     option.on('-v', '--version', 'Print version info') do
@@ -45,6 +73,8 @@ def main
     dotconfig = '.lili-rc.yml'
   )
 
+  finding_count = 0
+
   dotsmack.enumerate(filenames).each do |filename, config|
     config =
       if config.nil?
@@ -53,7 +83,20 @@ def main
         DEFAULT_CONFIGURATION.merge(YAML.load(config)).merge(configuration_flags)
       end
 
-    check(filename, config)
+    if !is_stat
+      check(filename, config, is_stat)
+    else
+      check(filename, config, is_stat) { |finding|
+        puts STAT_HEADER if finding_count == 0
+        puts ',' if finding_count > 0
+        print JSON.pretty_generate(finding).lines.map { |line| '    ' + line }.join
+        finding_count += 1
+      }
+    end
+  end
+
+  if is_stat && finding_count > 0
+    puts STAT_FOOTER
   end
 end
 

--- a/lib/lili.rb
+++ b/lib/lili.rb
@@ -108,6 +108,32 @@ class ALineEnding
     end
   end
 
+  def to_finding(line_ending_difference = false)
+    if line_ending_difference
+      observed = line_ending_difference[0]
+      preferred = line_ending_difference[1].inspect
+
+      if observed == NO_SUCH_FILE
+        "#{@filename}: #{NO_SUCH_FILE}"
+      else
+        {
+            :failure => true,
+            :rule => "Line ending",
+            :description => "Observed #{observed}",
+            :categories => [
+                "Style"
+            ],
+            :location => {
+                :path => "#{@filename}",
+            },
+            :recommendation => "Use the #{preferred}"
+        }
+      end
+    else
+      "#{@filename}: #{@line_ending}"
+    end
+  end
+
   def to_s(line_ending_difference = false)
     if line_ending_difference
       observed = line_ending_difference[0]
@@ -124,7 +150,7 @@ class ALineEnding
   end
 end
 
-def self.check(filename, configuration = nil)
+def self.check(filename, configuration = nil, is_stat = false)
   configuration =
     if configuration.nil?
       DEFAULT_CONFIGURATION
@@ -142,6 +168,10 @@ def self.check(filename, configuration = nil)
 
     line_ending_difference = line_ending.violate?(rules)
 
-    puts line_ending.to_s(line_ending_difference) if line_ending_difference
+    if is_stat
+      yield line_ending.to_finding(line_ending_difference) if line_ending_difference
+    else
+      puts line_ending.to_s(line_ending_difference) if line_ending_difference
+    end
   end
 end


### PR DESCRIPTION
Added --stat option to force output in STAT format:
![](https://i.gyazo.com/21f1c20e2916644d60334cb32e0bab93.png)
Example output:
![](https://i.gyazo.com/b0bcbc45d82e48688ae12f23b7e5ad79.png)

According to [this](https://github.com/mcandre/lili/pull/18)

> Neat! Would you mind making this format a --stat command line flag, and defaulting to a similar, but more typical ASCII format (no braces, no indentation, no quotes, silence all output unless findings > 0)?

I silence output for no findings, but leave braces, quotes etc, because as I understand STAT, output should be in json.

Let me know what do you think!
